### PR TITLE
ci: drop Laravel 10, add Laravel 12 to test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,14 +18,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2]
-        laravel: [11.*, 10.*]
+        laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.63
-          - laravel: 10.*
-            testbench: 8.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0",
+        "illuminate/contracts": "^11.0||^12.0",
         "openai-php/laravel": "^0.18.0",
         "spatie/laravel-markdown": "^2.5",
         "spatie/laravel-package-tools": "^1.16"


### PR DESCRIPTION
openai-php/laravel ^0.18.0 requires Laravel 11.29+, which breaks the L10 CI matrix job.

**Changes:**
- Drop Laravel 10 from CI (EOL anyway)
- Add Laravel 12 with Testbench 10 and Carbon 3
- Update illuminate/contracts constraint to ^11.0||^12.0

Fixes the failing run-tests workflow.